### PR TITLE
feat(tui-searcher): add filesystem fuzzy finder API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,7 @@ dependencies = [
  "frizbee",
  "ratatui",
  "tui-textarea",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/tui-searcher/Cargo.toml
+++ b/crates/tui-searcher/Cargo.toml
@@ -10,3 +10,4 @@ ratatui = "0.29.0"
 frizbee = { git = "https://github.com/saghen/frizbee.git", branch = "main" }
 anyhow = "1.0.100"
 tui-textarea = "0.7.0"
+walkdir = "2.5.0"

--- a/crates/tui-searcher/README.md
+++ b/crates/tui-searcher/README.md
@@ -1,30 +1,37 @@
 # tui-searcher
 
-A small, configurable TUI searcher (fzf-like).
+A small, configurable TUI fuzzy finder inspired by `fzf`.
 
-Features
+## Features
 - Interactive TUI built on `ratatui`.
 - Uses `frizbee` fuzzy matching for typo-tolerant search.
 - Builder-style API to configure prompts, column headers and widths.
+- Ready-to-use filesystem scanner (`Searcher::filesystem`) that walks directories recursively.
+- Rich outcome information including which entry was selected and the final query string.
 
-Quick example
+## Quick example
 
 ```rust
-use tui_searcher::{SearchMode, Searcher, UiConfig};
+use tui_searcher::{SearchData, SearchMode, Searcher, UiConfig};
 
+let data = SearchData::from_filesystem(".")?;
 let outcome = Searcher::new(data)
     .with_ui_config(UiConfig::tags_and_files())
-    .with_input_title("Search repo")
-    .with_headers_for(SearchMode::Facets, vec!["Tag", "Count", "Score"])
+    .with_start_mode(SearchMode::Files)
     .run()?;
+
+if let Some(file) = outcome.selected_file() {
+    println!("Selected file: {}", file.path);
+}
 ```
 
-Run the example
+## Run the examples
 
 ```bash
 cargo run -p tui_searcher --example demo
+cargo run -p tui_searcher --example filesystem -- /path/to/project
 ```
 
-Notes
+## Notes
 - This crate is meant to be a reusable component. You can integrate it into your own CLIs and customize headers/column widths using the builder API.
 - The underlying matching behavior is provided by `frizbee`.

--- a/crates/tui-searcher/examples/demo.rs
+++ b/crates/tui-searcher/examples/demo.rs
@@ -1,32 +1,32 @@
-use tui_searcher::{FacetRow, FileRow, SearchData, Searcher};
+use tui_searcher::{
+    FacetRow, FileRow, SearchData, SearchMode, SearchSelection, Searcher, UiConfig,
+};
 
 fn main() -> anyhow::Result<()> {
     // Build sample data
-    let facets = vec![
-        FacetRow {
-            name: "frontend".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "backend".into(),
-            count: 2,
-        },
-    ];
+    let facets = vec![FacetRow::new("frontend", 3), FacetRow::new("backend", 2)];
     let files = vec![
-        FileRow::new("src/main.rs".into(), vec!["frontend".into()]),
-        FileRow::new("src/lib.rs".into(), vec!["backend".into()]),
+        FileRow::new("src/main.rs", ["frontend"]),
+        FileRow::new("src/lib.rs", ["backend"]),
     ];
 
-    let data = SearchData {
-        repo_display: "example/repo".into(),
-        user_filter: "".into(),
-        facets,
-        files,
-    };
+    let data = SearchData::new()
+        .with_context("example/repo")
+        .with_initial_query("")
+        .with_facets(facets)
+        .with_files(files);
 
     // Minimal searcher configuration with prompt
-    let searcher = Searcher::new(data).with_input_title("workspace-prototype");
+    let searcher = Searcher::new(data)
+        .with_ui_config(UiConfig::tags_and_files())
+        .with_input_title("workspace-prototype")
+        .with_start_mode(SearchMode::Facets);
     let outcome = searcher.run()?;
     println!("Accepted? {}", outcome.accepted);
+    match outcome.selection {
+        Some(SearchSelection::File(file)) => println!("Selected file: {}", file.path),
+        Some(SearchSelection::Facet(facet)) => println!("Selected facet: {}", facet.name),
+        None => println!("No selection"),
+    }
     Ok(())
 }

--- a/crates/tui-searcher/examples/filesystem.rs
+++ b/crates/tui-searcher/examples/filesystem.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::path::PathBuf;
+
+use tui_searcher::{SearchSelection, Searcher};
+
+fn main() -> anyhow::Result<()> {
+    let root = env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| env::current_dir().expect("failed to resolve current dir"));
+
+    let title = root
+        .file_name()
+        .and_then(|name| name.to_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| root.to_string_lossy().into_owned());
+
+    let searcher = Searcher::filesystem(&root)?.with_input_title(title);
+
+    let outcome = searcher.run()?;
+
+    if !outcome.accepted {
+        println!("Search cancelled (query: '{}')", outcome.query);
+        return Ok(());
+    }
+
+    match outcome.selection {
+        Some(SearchSelection::File(file)) => println!("{}", file.path),
+        Some(SearchSelection::Facet(facet)) => println!("Facet: {}", facet.name),
+        None => println!("No selection"),
+    }
+
+    Ok(())
+}

--- a/examples/workspaces.rs
+++ b/examples/workspaces.rs
@@ -1,143 +1,80 @@
 mod common;
 use clap::Parser;
 use common::{Opts, apply_theme};
-use git_sparta::tui::{self, FacetRow, FileRow, SearchData};
+use git_sparta::tui::{self, FacetRow, FileRow, SearchData, SearchSelection};
 
 fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
-    let facets = vec![
-        FacetRow {
-            name: "backend".into(),
-            count: 7,
-        },
-        FacetRow {
-            name: "frontend".into(),
-            count: 5,
-        },
-        FacetRow {
-            name: "integration".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "mobile".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "qa".into(),
-            count: 2,
-        },
-        FacetRow {
-            name: "devops".into(),
-            count: 6,
-        },
-        FacetRow {
-            name: "docs".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "security".into(),
-            count: 2,
-        },
-        FacetRow {
-            name: "infra".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "legacy".into(),
-            count: 1,
-        },
-        FacetRow {
-            name: "api".into(),
-            count: 5,
-        },
-        FacetRow {
-            name: "db".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "tests".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "scripts".into(),
-            count: 2,
-        },
+
+    let facets: Vec<FacetRow> = [
+        ("backend", 7),
+        ("frontend", 5),
+        ("integration", 3),
+        ("mobile", 4),
+        ("qa", 2),
+        ("devops", 6),
+        ("docs", 3),
+        ("security", 2),
+        ("infra", 4),
+        ("legacy", 1),
+        ("api", 5),
+        ("db", 3),
+        ("tests", 4),
+        ("scripts", 2),
+    ]
+    .into_iter()
+    .map(|(name, count)| FacetRow::new(name, count))
+    .collect();
+
+    let files: Vec<FileRow> = vec![
+        FileRow::new("services/catalog/lib.rs", ["backend", "integration"]),
+        FileRow::new("services/payments/api.rs", ["backend"]),
+        FileRow::new("clients/web/src/app.tsx", ["frontend"]),
+        FileRow::new(
+            "clients/mobile/app/lib/main.dart",
+            ["mobile", "integration"],
+        ),
+        FileRow::new("qa/scenarios/payment.feature", ["qa", "backend"]),
+        FileRow::new("devops/ci.yml", ["devops"]),
+        FileRow::new("docs/architecture.md", ["docs"]),
+        FileRow::new("security/audit.log", ["security", "infra"]),
+        FileRow::new("infra/terraform/main.tf", ["infra", "devops"]),
+        FileRow::new("legacy/old_service.rs", ["legacy"]),
+        FileRow::new("api/routes.rs", ["api", "backend"]),
+        FileRow::new("db/schema.sql", ["db"]),
+        FileRow::new("tests/test_api.rs", ["tests", "api"]),
+        FileRow::new("scripts/deploy.sh", ["scripts", "devops"]),
+        FileRow::new("clients/web/src/components/button.tsx", ["frontend"]),
+        FileRow::new("clients/mobile/app/lib/utils.dart", ["mobile"]),
+        FileRow::new("qa/scenarios/login.feature", ["qa", "frontend"]),
+        FileRow::new("infra/ansible/playbook.yml", ["infra", "devops"]),
+        FileRow::new("docs/api.md", ["docs", "api"]),
+        FileRow::new("db/migrations/001_init.sql", ["db", "backend"]),
     ];
 
-    let files = vec![
-        FileRow::new(
-            "services/catalog/lib.rs".into(),
-            vec!["backend".into(), "integration".into()],
-        ),
-        FileRow::new("services/payments/api.rs".into(), vec!["backend".into()]),
-        FileRow::new("clients/web/src/app.tsx".into(), vec!["frontend".into()]),
-        FileRow::new(
-            "clients/mobile/app/lib/main.dart".into(),
-            vec!["mobile".into(), "integration".into()],
-        ),
-        FileRow::new(
-            "qa/scenarios/payment.feature".into(),
-            vec!["qa".into(), "backend".into()],
-        ),
-        FileRow::new("devops/ci.yml".into(), vec!["devops".into()]),
-        FileRow::new("docs/architecture.md".into(), vec!["docs".into()]),
-        FileRow::new(
-            "security/audit.log".into(),
-            vec!["security".into(), "infra".into()],
-        ),
-        FileRow::new(
-            "infra/terraform/main.tf".into(),
-            vec!["infra".into(), "devops".into()],
-        ),
-        FileRow::new("legacy/old_service.rs".into(), vec!["legacy".into()]),
-        FileRow::new("api/routes.rs".into(), vec!["api".into(), "backend".into()]),
-        FileRow::new("db/schema.sql".into(), vec!["db".into()]),
-        FileRow::new(
-            "tests/test_api.rs".into(),
-            vec!["tests".into(), "api".into()],
-        ),
-        FileRow::new(
-            "scripts/deploy.sh".into(),
-            vec!["scripts".into(), "devops".into()],
-        ),
-        FileRow::new(
-            "clients/web/src/components/button.tsx".into(),
-            vec!["frontend".into()],
-        ),
-        FileRow::new(
-            "clients/mobile/app/lib/utils.dart".into(),
-            vec!["mobile".into()],
-        ),
-        FileRow::new(
-            "qa/scenarios/login.feature".into(),
-            vec!["qa".into(), "frontend".into()],
-        ),
-        FileRow::new(
-            "infra/ansible/playbook.yml".into(),
-            vec!["infra".into(), "devops".into()],
-        ),
-        FileRow::new("docs/api.md".into(), vec!["docs".into(), "api".into()]),
-        FileRow::new(
-            "db/migrations/001_init.sql".into(),
-            vec!["db".into(), "backend".into()],
-        ),
-    ];
+    let data = SearchData::new()
+        .with_context("workspace-prototype")
+        .with_initial_query("workspace")
+        .with_facets(facets)
+        .with_files(files);
 
-    let data = SearchData {
-        repo_display: "workspace-prototype".into(),
-        user_filter: "workspace".into(),
-        facets,
-        files,
-    };
-
-    let searcher = tui::Searcher::new(data).with_input_title("workspace");
+    let searcher = tui::Searcher::new(data)
+        .with_ui_config(tui::UiConfig::tags_and_files())
+        .with_input_title("workspace");
     let searcher = apply_theme(searcher, &opts);
 
     let outcome = searcher.run()?;
-    if outcome.accepted {
-        println!("Workspace walkthrough accepted");
-    } else {
-        println!("Workspace walkthrough cancelled");
+    if !outcome.accepted {
+        println!("Workspace walkthrough cancelled (query: {})", outcome.query);
+        return Ok(());
+    }
+
+    match outcome.selection {
+        Some(SearchSelection::Facet(facet)) => {
+            println!("Selected workspace facet: {}", facet.name)
+        }
+        Some(SearchSelection::File(file)) => println!("Selected workspace file: {}", file.path),
+        None => println!("Workspace walkthrough accepted"),
     }
 
     Ok(())

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -90,21 +90,21 @@ pub fn run(
     let patterns: Vec<String> = unique_patterns.into_iter().collect();
     let facets = tag_counts
         .into_iter()
-        .map(|(name, count)| tui::FacetRow { name, count })
+        .map(|(name, count)| tui::FacetRow::new(name, count))
         .collect();
     let files = file_map
         .into_iter()
-        .map(|(path, tags)| tui::FileRow::new(path, tags.into_iter().collect()))
+        .map(|(path, tags)| tui::FileRow::new(path, tags.into_iter()))
         .collect();
 
-    let mut searcher_builder = tui::Searcher::new(tui::SearchData {
-        repo_display: root.display().to_string(),
-        user_filter: tag.to_string(),
-        facets,
-        files,
-    });
+    let data = tui::SearchData::new()
+        .with_context(root.display().to_string())
+        .with_initial_query(tag)
+        .with_facets(facets)
+        .with_files(files);
 
-    searcher_builder = searcher_builder.with_ui_config(tui::UiConfig::tags_and_files());
+    let mut searcher_builder =
+        tui::Searcher::new(data).with_ui_config(tui::UiConfig::tags_and_files());
 
     if let Some(name) = theme {
         // Use centralized theme lookup from the tui crate; with_theme_name is


### PR DESCRIPTION
## Summary
- add filesystem-powered data source and richer builder helpers to the tui-searcher crate
- update the app runtime to honour initial query/context and return detailed selections
- refresh examples/docs and parent git-sparta integration to use the new API surface

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e4934aac108332a145bedc6d38caa8