### PR TITLE
Refactor tui-searcher into standalone fuzzy finder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,7 @@ dependencies = [
  "frizbee",
  "ratatui",
  "tui-textarea",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/tui-searcher/Cargo.toml
+++ b/crates/tui-searcher/Cargo.toml
@@ -10,3 +10,4 @@ ratatui = "0.29.0"
 frizbee = { git = "https://github.com/saghen/frizbee.git", branch = "main" }
 anyhow = "1.0.100"
 tui-textarea = "0.7.0"
+walkdir = "2.5.0"

--- a/crates/tui-searcher/README.md
+++ b/crates/tui-searcher/README.md
@@ -1,6 +1,6 @@
 # tui-searcher
 
-A small, configurable TUI searcher (fzf-like).
+A small, configurable TUI searcher (fzf-like) with filesystem search helpers.
 
 Features
 - Interactive TUI built on `ratatui`.
@@ -10,19 +10,42 @@ Features
 Quick example
 
 ```rust
-use tui_searcher::{SearchMode, Searcher, UiConfig};
+use tui_searcher::{FacetRow, FileRow, SearchData, SearchMode, Searcher, UiConfig};
+
+let data = SearchData::new()
+    .with_facets(vec![FacetRow::new("backend", 4)])
+    .with_files(vec![FileRow::new("src/lib.rs".into(), vec!["backend".into()])]);
 
 let outcome = Searcher::new(data)
     .with_ui_config(UiConfig::tags_and_files())
     .with_input_title("Search repo")
     .with_headers_for(SearchMode::Facets, vec!["Tag", "Count", "Score"])
     .run()?;
+
+if let Some(selection) = outcome.selection() {
+    println!("Selection: {selection:?}");
+}
+```
+
+Filesystem search convenience:
+
+```rust
+use tui_searcher::{SearchSelection, Searcher};
+
+let outcome = Searcher::filesystem_current_dir()?
+    .with_input_title("Files")
+    .run()?;
+
+if let Some(SearchSelection::File(file)) = outcome.selection() {
+    println!("Selected: {}", file.path);
+}
 ```
 
 Run the example
 
 ```bash
 cargo run -p tui_searcher --example demo
+cargo run -p tui_searcher --example filesystem
 ```
 
 Notes

--- a/crates/tui-searcher/examples/demo.rs
+++ b/crates/tui-searcher/examples/demo.rs
@@ -1,32 +1,29 @@
-use tui_searcher::{FacetRow, FileRow, SearchData, Searcher};
+use tui_searcher::{FacetRow, FileRow, SearchData, SearchSelection, Searcher};
 
 fn main() -> anyhow::Result<()> {
     // Build sample data
-    let facets = vec![
-        FacetRow {
-            name: "frontend".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "backend".into(),
-            count: 2,
-        },
-    ];
-    let files = vec![
-        FileRow::new("src/main.rs".into(), vec!["frontend".into()]),
-        FileRow::new("src/lib.rs".into(), vec!["backend".into()]),
-    ];
-
-    let data = SearchData {
-        repo_display: "example/repo".into(),
-        user_filter: "".into(),
-        facets,
-        files,
-    };
+    let data = SearchData::new()
+        .with_facets(vec![
+            FacetRow::new("frontend", 3),
+            FacetRow::new("backend", 2),
+        ])
+        .with_files(vec![
+            FileRow::new("src/main.rs".into(), vec!["frontend".into()]),
+            FileRow::new("src/lib.rs".into(), vec!["backend".into()]),
+        ]);
 
     // Minimal searcher configuration with prompt
     let searcher = Searcher::new(data).with_input_title("workspace-prototype");
     let outcome = searcher.run()?;
-    println!("Accepted? {}", outcome.accepted);
+    match (outcome.is_accepted(), outcome.selection()) {
+        (true, Some(SearchSelection::Facet(facet))) => {
+            println!("Accepted facet: {}", facet.name);
+        }
+        (true, Some(SearchSelection::File(file))) => {
+            println!("Accepted file: {}", file.path);
+        }
+        (true, None) => println!("Accepted with no selection"),
+        (false, _) => println!("Search cancelled"),
+    }
     Ok(())
 }

--- a/crates/tui-searcher/examples/filesystem.rs
+++ b/crates/tui-searcher/examples/filesystem.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use tui_searcher::{SearchSelection, Searcher};
+
+fn main() -> anyhow::Result<()> {
+    let root = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or(std::env::current_dir()?);
+
+    let display = root.display().to_string();
+    let outcome = Searcher::filesystem(&root)?
+        .with_input_title(format!("search: {display}"))
+        .run()?;
+
+    if outcome.is_accepted() {
+        match outcome.selection() {
+            Some(SearchSelection::File(file)) => println!("{}", file.path),
+            _ => println!("No file selected"),
+        }
+    } else {
+        println!("Search cancelled");
+    }
+
+    Ok(())
+}

--- a/crates/tui-searcher/src/lib.rs
+++ b/crates/tui-searcher/src/lib.rs
@@ -9,7 +9,12 @@ pub mod utils;
 pub use app::run;
 pub use input::SearchInput;
 pub use theme::{LIGHT, SLATE, SOLARIZED, Theme};
-pub use types::{FacetRow, FileRow, PaneUiConfig, SearchData, SearchMode, UiConfig};
+pub use types::{
+    FacetRow, FileRow, PaneUiConfig, SearchData, SearchMode, SearchOutcome, SearchSelection,
+    UiConfig,
+};
+
+use std::path::Path;
 
 use ratatui::layout::Constraint;
 
@@ -40,6 +45,16 @@ impl Searcher {
             ui_config: None,
             theme: None,
         }
+    }
+
+    /// Create a Searcher populated with every file under the provided root.
+    pub fn filesystem(root: impl AsRef<Path>) -> anyhow::Result<Self> {
+        SearchData::filesystem(root).map(Self::new)
+    }
+
+    /// Convenience for searching the current working directory recursively.
+    pub fn filesystem_current_dir() -> anyhow::Result<Self> {
+        SearchData::filesystem_current_dir().map(Self::new)
     }
 
     pub fn with_input_title(mut self, title: impl Into<String>) -> Self {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -6,66 +6,21 @@ use git_sparta::tui::{self, FacetRow, FileRow, SearchData};
 fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     let facets = vec![
-        FacetRow {
-            name: "app/core".into(),
-            count: 12,
-        },
-        FacetRow {
-            name: "app/ui".into(),
-            count: 9,
-        },
-        FacetRow {
-            name: "docs".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "ops".into(),
-            count: 6,
-        },
-        FacetRow {
-            name: "tooling".into(),
-            count: 8,
-        },
-        FacetRow {
-            name: "infra".into(),
-            count: 5,
-        },
-        FacetRow {
-            name: "ci".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "tests".into(),
-            count: 7,
-        },
-        FacetRow {
-            name: "examples".into(),
-            count: 2,
-        },
-        FacetRow {
-            name: "legacy".into(),
-            count: 1,
-        },
-        FacetRow {
-            name: "frontend".into(),
-            count: 10,
-        },
-        FacetRow {
-            name: "backend".into(),
-            count: 11,
-        },
-        FacetRow {
-            name: "api".into(),
-            count: 6,
-        },
-        FacetRow {
-            name: "db".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "scripts".into(),
-            count: 3,
-        },
+        FacetRow::new("app/core", 12),
+        FacetRow::new("app/ui", 9),
+        FacetRow::new("docs", 4),
+        FacetRow::new("ops", 6),
+        FacetRow::new("tooling", 8),
+        FacetRow::new("infra", 5),
+        FacetRow::new("ci", 3),
+        FacetRow::new("tests", 7),
+        FacetRow::new("examples", 2),
+        FacetRow::new("legacy", 1),
+        FacetRow::new("frontend", 10),
+        FacetRow::new("backend", 11),
+        FacetRow::new("api", 6),
+        FacetRow::new("db", 4),
+        FacetRow::new("scripts", 3),
     ];
 
     let files = vec![
@@ -127,18 +82,13 @@ fn main() -> anyhow::Result<()> {
         FileRow::new("docs/api.md".into(), vec!["docs".into(), "api".into()]),
     ];
 
-    let data = SearchData {
-        repo_display: "demo-repo".into(),
-        user_filter: "demo".into(),
-        facets,
-        files,
-    };
+    let data = SearchData::new().with_facets(facets).with_files(files);
 
     let searcher = tui::Searcher::new(data).with_input_title("demo");
     let searcher = apply_theme(searcher, &opts);
 
     let outcome = searcher.run()?;
-    if outcome.accepted {
+    if outcome.is_accepted() {
         println!("Demo accepted – imagine emitting sparse patterns here");
     } else {
         println!("Demo aborted");

--- a/examples/workspaces.rs
+++ b/examples/workspaces.rs
@@ -6,62 +6,20 @@ use git_sparta::tui::{self, FacetRow, FileRow, SearchData};
 fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     let facets = vec![
-        FacetRow {
-            name: "backend".into(),
-            count: 7,
-        },
-        FacetRow {
-            name: "frontend".into(),
-            count: 5,
-        },
-        FacetRow {
-            name: "integration".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "mobile".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "qa".into(),
-            count: 2,
-        },
-        FacetRow {
-            name: "devops".into(),
-            count: 6,
-        },
-        FacetRow {
-            name: "docs".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "security".into(),
-            count: 2,
-        },
-        FacetRow {
-            name: "infra".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "legacy".into(),
-            count: 1,
-        },
-        FacetRow {
-            name: "api".into(),
-            count: 5,
-        },
-        FacetRow {
-            name: "db".into(),
-            count: 3,
-        },
-        FacetRow {
-            name: "tests".into(),
-            count: 4,
-        },
-        FacetRow {
-            name: "scripts".into(),
-            count: 2,
-        },
+        FacetRow::new("backend", 7),
+        FacetRow::new("frontend", 5),
+        FacetRow::new("integration", 3),
+        FacetRow::new("mobile", 4),
+        FacetRow::new("qa", 2),
+        FacetRow::new("devops", 6),
+        FacetRow::new("docs", 3),
+        FacetRow::new("security", 2),
+        FacetRow::new("infra", 4),
+        FacetRow::new("legacy", 1),
+        FacetRow::new("api", 5),
+        FacetRow::new("db", 3),
+        FacetRow::new("tests", 4),
+        FacetRow::new("scripts", 2),
     ];
 
     let files = vec![
@@ -123,18 +81,13 @@ fn main() -> anyhow::Result<()> {
         ),
     ];
 
-    let data = SearchData {
-        repo_display: "workspace-prototype".into(),
-        user_filter: "workspace".into(),
-        facets,
-        files,
-    };
+    let data = SearchData::new().with_facets(facets).with_files(files);
 
     let searcher = tui::Searcher::new(data).with_input_title("workspace");
     let searcher = apply_theme(searcher, &opts);
 
     let outcome = searcher.run()?;
-    if outcome.accepted {
+    if outcome.is_accepted() {
         println!("Workspace walkthrough accepted");
     } else {
         println!("Workspace walkthrough cancelled");

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -88,21 +88,17 @@ pub fn run(
     }
 
     let patterns: Vec<String> = unique_patterns.into_iter().collect();
-    let facets = tag_counts
+    let facets: Vec<_> = tag_counts
         .into_iter()
-        .map(|(name, count)| tui::FacetRow { name, count })
+        .map(|(name, count)| tui::FacetRow::new(name, count))
         .collect();
-    let files = file_map
+    let files: Vec<_> = file_map
         .into_iter()
         .map(|(path, tags)| tui::FileRow::new(path, tags.into_iter().collect()))
         .collect();
 
-    let mut searcher_builder = tui::Searcher::new(tui::SearchData {
-        repo_display: root.display().to_string(),
-        user_filter: tag.to_string(),
-        facets,
-        files,
-    });
+    let data = tui::SearchData::new().with_facets(facets).with_files(files);
+    let mut searcher_builder = tui::Searcher::new(data);
 
     searcher_builder = searcher_builder.with_ui_config(tui::UiConfig::tags_and_files());
 
@@ -115,7 +111,7 @@ pub fn run(
 
     let outcome = searcher_builder.run()?;
 
-    if !outcome.accepted {
+    if !outcome.is_accepted() {
         anyhow::bail!("aborted by user");
     }
 


### PR DESCRIPTION
## Summary
- refactor the tui-searcher data model around a builder-style API, add filesystem helpers, and surface selection results from the TUI
- expose Searcher::filesystem conveniences, document the new flows, and ship a filesystem example alongside the demo
- adopt the new idioms throughout git-sparta so the parent crate builds against the updated API

## Testing
- cargo fmt
- cargo check


------
https://chatgpt.com/codex/tasks/task_e_68e4934aac108332a145bedc6d38caa8